### PR TITLE
!を赤色に変更する処理を追加

### DIFF
--- a/password_manager.sh
+++ b/password_manager.sh
@@ -27,8 +27,7 @@ echo 'ユーザー名を入力してください : '
 read user
 echo 'パスワードを入力してください : '
 read pass
-
-echo 'Thank you!'
+printf 'Thank you\033[31m!\033[0m'
 
 #色を変更
 #バリデーション処理


### PR DESCRIPTION
エスケープ文字\eでは、シェルによっては正しく動作しない為、\033を使用。
bash以外のシェルでも、赤色で出力されるようになる。