### PR TITLE
count_and_display_errors関数の処理内容変更し、不要な処理を削除

### DIFF
--- a/password_manager.sh
+++ b/password_manager.sh
@@ -27,19 +27,13 @@ validate_input()
     fi
 }
 
-count_and_display_errors()
+display_errors()
 {
-    error_num=0
     for error in "${errors[@]}"; do
-        if [ -n "$error" ]; then
-            ((error_num++))
+     if [ -n "$error" ]; then
+        printf "%s\n" "${error}"
         fi
     done
-
-    if [ "$error_num" -ne 0 ]; then
-        printf "%s\n" "${errors[@]}"
-        exit
-    fi
 }
 
 save_login_data() {
@@ -48,7 +42,7 @@ save_login_data() {
 
 password_manager_input
 validate_input
-count_and_display_errors
+display_errors
 save_login_data
 printf 'Thank you\033[31m!\033[0m\n'
 


### PR DESCRIPTION
エラーメッセージをカウントせず、for文で直接出力
エラーメッセージが無い場合は出力しないように変更
処理の簡素化、空行の出力抑制を実現