### PR TITLE
ユーザー入力処理をサブシェル化

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 user_input.txt
+error.txt

--- a/password_manager.sh
+++ b/password_manager.sh
@@ -28,11 +28,14 @@ done
 
 # エラーが無い場合は感謝メッセージ出力、ある場合はエラーメッセージ出力、
 if [ -z "$error_messages" ]; then
-    echo "$service_name":"$user_name":"$password" >> user_input.txt 2>error.txt
-        if [ $? -ne 0 ]; then
-            printf '\033[31m入力内容の保存に失敗しました\033[0m\n'
-            return
-        fi
+    (
+        echo "$service_name":"$user_name":"$password" >> user_input.txt
+    ) 2>error.txt
+
+    if [ $? -ne 0 ]; then
+        printf '\033[31m入力内容の保存に失敗しました\033[0m\n'
+        return
+    fi
     printf 'Thank you\033[31m!\033[0m\n'
 else
     for i in "${error_messages[@]}"; do


### PR DESCRIPTION
### 概要
ユーザー入力を保存する処理を、サブシェルで実行するように変更しました。また、エラー標準出力のリダイレクト先の'error.txt'を'.gitignore'に追加しました。

### 主な変更点
- 標準エラー出力を分離するため、ユーザー入力の保存処理をサブシェル化
- サブシェルの標準エラー出力を'error.txt'にリダイレクト
- .gitignoreにerror.txtを追加し、gitの管理から削除

### 手動テストによる動作確認済みの内容
- 標準エラー出力のリダイレクト先ファイルへの出力

### その他・問題点
<!-- 特になし -->