### PR TITLE
feat:文字数超過の入力があった場合、エラー文を追加する処理を実装

### DIFF
--- a/password_manager
+++ b/password_manager
@@ -6,7 +6,13 @@ declare -a input_errors=(
     'ユーザー名が入力されていません'
     'パスワードが入力されていません'
 )
+declare -a length_errors=(
+    'サービス名は50文字以内で入力してください'
+    'ユーザー名は50文字以内で入力してください'
+    'パスワードは50文字以内で入力してください'
+)
 declare -a error_messages=()
+MAX_CAHRACTERS=50
 
 echo 'パスワードマネージャーへようこそ！'
 read -p 'サービス名を入力して下さい：' user_inputs[0]
@@ -18,10 +24,10 @@ read -p 'パスワードを入力して下さい：' user_inputs[2]
 for indent in "${!user_inputs[@]}"; do
     if [ -z "${user_inputs[$indent]}" ]; then
         error_messages+=("${input_errors[$indent]}")
+    elif [ "${#user_inputs[$indent]}" -ge "$MAX_CAHRACTERS" ]; then
+        error_messages+="${length_errors[$indent]}"
     fi
 done
-# 代入の確認テスト
-echo "${error_messages[@]}"
 
 # TODO:エラーの有無による条件分岐
 echo "$service_name" : "$user_name" : "$password" >> user_inputs


### PR DESCRIPTION
### 概要
- ユーザー入力の文字数が50文字を超過した場合、`error_massages`配列にエラー文を追加する処理を実装しました。

### 変更箇所
- `length_errors`配列を宣言し、文字超過時のエラー文を定義
- `MAX_CHARACTERS=50`を定義し、入力の文字数超過を確認する条件式を追加

### 手動テストによる動作確認済の事項
- 文字数超過の入力を行い、適切なエラー文が`error_messages`に追加されることを確認

### 作業の切り分け:次回の作業に引き継ぎ
- エラーの有無による条件分岐の作成
