### PR TITLE
style:エラー文の出力を赤色に変更し、視認性向上

### DIFF
--- a/password_manager
+++ b/password_manager
@@ -2,14 +2,14 @@
 
 declare -a user_inputs=("service_name" "user_name" "password")
 declare -a input_errors=(
-    'サービス名が入力されていません'
-    'ユーザー名が入力されていません'
-    'パスワードが入力されていません'
+    '\033[31mサービス名が入力されていません\033[0m'
+    '\033[31mユーザー名が入力されていません\033[0m'
+    '\033[31mパスワードが入力されていません\033[0m'
 )
 declare -a length_errors=(
-    'サービス名は50文字以内で入力してください'
-    'ユーザー名は50文字以内で入力してください'
-    'パスワードは50文字以内で入力してください'
+    '\033[31mサービス名は50文字以内で入力してください\033[0m'
+    '\033[31mユーザー名は50文字以内で入力してください\033[0m'
+    '\033[31mパスワードは50文字以内で入力してください\033[0m'
 )
 declare -a error_messages=()
 MAX_CAHRACTERS=50
@@ -25,9 +25,11 @@ for indent in "${!user_inputs[@]}"; do
     if [ -z "${user_inputs[$indent]}" ]; then
         error_messages+=("${input_errors[$indent]}")
     elif [ "${#user_inputs[$indent]}" -ge "$MAX_CAHRACTERS" ]; then
-        error_messages+="${length_errors[$indent]}"
+        error_messages+=("${length_errors[$indent]}")
     fi
 done
+
+#TODO:パスワードの保存に失敗した場合の処理を追加
 
 if [ -z "$error_messages" ]; then
     # エラーが無い場合、ファイルにリダイレクトして、感謝文を出力
@@ -36,6 +38,6 @@ if [ -z "$error_messages" ]; then
 else
     # エラーがある場合、配列のエラー文を出力
     for error in "${error_messages[@]}"; do
-        echo $error
+        echo -e $error
     done
 fi


### PR DESCRIPTION
### 概要
- エラー文の出力を赤色に変更し、視認性を向上させました。

### 変更箇所
- エラー文の文字色をエスケープシーケンスを使用して赤色に変更
- `echo`に-eオプションを追加し、色付けに対応

### 手動テストによる動作確認済
- エラー文が赤色で出力されることを確認

### 作業の切り分け:次回の作業に引き継ぎ
- パスワード保存失敗時のエラーハンドリングの追加

