### PR TITLE
feat:データの保存失敗時、エラー文を表示する処理を追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 user_inputs
+error.txt

--- a/password_manager
+++ b/password_manager
@@ -33,7 +33,13 @@ done
 
 if [ -z "$error_messages" ]; then
     # エラーが無い場合、ファイルにリダイレクトして、感謝文を出力
-    echo "${user_inputs[0]}":"${user_inputs[1]}":"${user_inputs[2]}" >> user_inputs
+    (echo "${user_inputs[0]}":"${user_inputs[1]}":"${user_inputs[2]}" >> d/user_inputs) 2>> error.txt
+
+    if [ $? -ne 0 ]; then
+        printf '\033[31m入力内容の保存に失敗しました\033[0m\n'
+        return
+    fi
+
     echo -e "Thank you\033[31m!\033[0m"
 else
     # エラーがある場合、配列のエラー文を出力

--- a/password_manager
+++ b/password_manager
@@ -33,7 +33,7 @@ done
 
 if [ -z "$error_messages" ]; then
     # エラーが無い場合、ファイルにリダイレクトして、感謝文を出力
-    (echo "${user_inputs[0]}":"${user_inputs[1]}":"${user_inputs[2]}" >> d/user_inputs) 2>> error.txt
+    (echo "${user_inputs[0]}":"${user_inputs[1]}":"${user_inputs[2]}" >> user_inputs) 2>> error.txt
 
     if [ $? -ne 0 ]; then
         printf '\033[31m入力内容の保存に失敗しました\033[0m\n'


### PR DESCRIPTION
### 概要
- データの保存失敗時、エラー文を表示し、記録する処理を追加しました。

### 変更箇所
- ユーザーに表示されるbashエラーに対応する為、ファイルへの保存処理をサブシェル化し、エラーを`error.txt`へリダイレクト
-ユーザーにエラーをフィードバックする為、 データの保存に失敗した場合の条件分岐を追加
- 標準エラー出力のリダイレクト先のファイルを`.gitignore`に追加し、追跡対象から除外

### 手動テストによる動作確認済の事項
- 疑似的にエラーを発生させ、エラー文が`error.txt`へ保存される事を確認

### 作業の切り分け:次回の作業に引き継ぎ
- 可読性を向上の為、バリデーション処理とファイルへの保存処理を関数化
