### PR TITLE
ref:変数をlocalで宣言し、スコープを明確化

### DIFF
--- a/password_manager
+++ b/password_manager
@@ -40,8 +40,8 @@ save_user_inputs()
 
 add_password()
 {
-    declare -A user_inputs=(['service_name']='' ['user_name']='' ['password']='')
-    declare -a error_messages=()
+    local -A user_inputs=(['service_name']='' ['user_name']='' ['password']='')
+    local -a error_messages=()
 
     read -p 'サービス名を入力して下さい：' user_inputs['service_name']
     read -p 'ユーザー名を入力して下さい：' user_inputs['user_name']


### PR DESCRIPTION
### 概要
- 変数をl`ocal`で宣言し、スコープを明確化しました。

### 変更箇所
- 変数宣言`declare`を`local`に変更

### 手動テストによる動作確認済の事項
- 変数への代入が正常に動作することを確認
- 変数が、関数外の影響を受けないことを確認