### PR TITLE
fix:未登録のサービス名が入力された場合、エラーを出力する処理を追加

### DIFF
--- a/password_manager
+++ b/password_manager
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+# TODO:エラーメッセージに句点の追加
 # 未入力項目と文字数超過を確認し、該当するエラーメッセージを配列に追加
 validation_user_inputs()
 {
@@ -63,9 +64,19 @@ add_password()
 
 get_password()
 {
-    read -p 'サービス名を入力してください:' service_name
-    grep ^"$service_name" user_inputs | awk -F ':' '{print "\nサービス名:"$1 "\nユーザー名:"$2 "\nパスワード:"$3}'
-    # TODO:サービス名が登録されていなった場合、エラーを出力
+    read -p 'サービス名を入力してください:' search_name
+    # TODO:サービス名が未入力の場合の処理
+        # if [ -z "$search_name" ]; then
+        # echo -e "\nサービス名が入力されていません。"
+        # return
+        # fi
+        
+    matched_data=$(grep "^$search_name" user_inputs)
+    if [ $? -eq 0 ]; then
+        echo "$matched_data" | awk -F ':' '{print "\nサービス名:"$1 "\nユーザー名:"$2 "\nパスワード:"$3}'
+    else
+        echo -e '\nそのサービス名は登録されていません。'
+    fi
 }
 
 echo 'パスワードマネージャーへようこそ！'


### PR DESCRIPTION
### 概要
- 未登録のサービス名が入力された場合の、エラー処理を追加しました。

### 変更箇所
- 未登録のサービス名を入力した場合、エラー文を出力
- サービス名の有無確認を、grepの終了ステータスで判定する

### 手動テストによる動作確認済の事項
- 未登録のサービス名を入力した場合、エラー文の出力を確認

### 作業の切り分け:次回の作業に引き継ぎ
- サービス名が未入力の場合、全てのデータが出力される。未入力の場合、エラー文を出力する処理を追加。
