### PR TITLE
 fix:サービス名が未入力の場合、エラー文を出力する処理を追加

### DIFF
--- a/password_manager
+++ b/password_manager
@@ -65,7 +65,6 @@ add_password()
 get_password()
 {
     read -p 'サービス名を入力してください:' search_name
-    # TODO:サービス名が未入力の場合の処理
         if [ -z "$search_name" ]; then
             echo -e "\nサービス名が入力されていません。"
             return

--- a/password_manager
+++ b/password_manager
@@ -66,11 +66,11 @@ get_password()
 {
     read -p 'サービス名を入力してください:' search_name
     # TODO:サービス名が未入力の場合の処理
-        # if [ -z "$search_name" ]; then
-        # echo -e "\nサービス名が入力されていません。"
-        # return
-        # fi
-        
+        if [ -z "$search_name" ]; then
+            echo -e "\nサービス名が入力されていません。"
+            return
+        fi
+
     matched_data=$(grep "^$search_name" user_inputs)
     if [ $? -eq 0 ]; then
         echo "$matched_data" | awk -F ':' '{print "\nサービス名:"$1 "\nユーザー名:"$2 "\nパスワード:"$3}'


### PR DESCRIPTION
### 概要
- `search_name`が未入力の場合、エラー文を出力し処理を中断するロジックを追加しました。

### 変更箇所
- `serch_name`の値を確認するif文追加
- エラー文を出力
-  処理を中断する`return`を追加

### 手動テストによる動作確認済の事項
- `search_name`が未入力の場合、エラー文出力し処理が中断される事を確認
