### PR TITLE
style:メッセージの出力形式を変更し、仕様に従った形式に修正

### DIFF
--- a/password_manager
+++ b/password_manager
@@ -1,18 +1,17 @@
 #!/bin/bash
 
-# TODO:エラーメッセージに句点の追加
 # 未入力項目と文字数超過を確認し、該当するエラーメッセージを配列に追加
 validation_user_inputs()
 {
     local -A input_errors=(
-        ['service_name']='\033[31mサービス名が入力されていません\033[0m'
-        ['user_name']='\033[31mユーザー名が入力されていません\033[0m'
-        ['password']='\033[31mパスワードが入力されていません\033[0m'
+        ['service_name']='サービス名が入力されていません。'
+        ['user_name']='ユーザー名が入力されていません。'
+        ['password']='パスワードが入力されていません。'
     )
     local -A length_errors=(
-        ['service_name']='\033[31mサービス名は50文字以内で入力してください\033[0m'
-        ['user_name']='\033[31mユーザー名は50文字以内で入力してください\033[0m'
-        ['password']='\033[31mパスワードは50文字以内で入力してください\033[0m'
+        ['service_name']='サービス名は50文字以内で入力してください。'
+        ['user_name']='ユーザー名は50文字以内で入力してください。'
+        ['password']='パスワードは50文字以内で入力してください。'
     )
     MAX_CAHRACTERS=50
     # user_inputsのインデントをindentとしてループし、ユーザー入力情報とエラー文を紐づける
@@ -32,7 +31,7 @@ save_user_inputs()
     ) 2>> error.txt
 
     if [ $? -ne 0 ]; then
-        echo -e  '\033[31m入力内容の保存に失敗しました\033[0m'
+        echo   '入力内容の保存に失敗しました。'
         return
     fi
 
@@ -57,7 +56,7 @@ add_password()
     else
         # 入力に異常がある場合、配列のエラー文を出力
         for error in "${error_messages[@]}"; do
-            echo -e $error
+            echo  $error
         done
     fi
 }
@@ -76,7 +75,7 @@ get_password()
     else
         echo -e '\nそのサービス名は登録されていません。'
     fi
-}
+}@
 
 echo 'パスワードマネージャーへようこそ！'
 while true; do
@@ -95,7 +94,7 @@ while true; do
             ;;
         *)
             echo ''
-            echo -e '\033[31m選択肢から入力してください\033[0m'
+            echo  '選択肢から入力してください。'
             ;;
     esac
 done


### PR DESCRIPTION
### 概要
- 作業完了と、エラーのメッセージ出力形式を変更し、仕様に従った形式に修正しました。

### 変更箇所
- 出力メッセージの色を黒色に統一し、句点を追加
- `echo`の`-e`オプションを削除

### 手動テストによる動作確認済の事項
- 全てのメッセージの正常な出力と、色の変更を確認
