### PR TITLE
feat:パスワードファイルを暗号化と元ファイルを削除する処理を追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 user_inputs
 error.txt
+user_inputs.gpg

--- a/password_manager.sh
+++ b/password_manager.sh
@@ -40,7 +40,6 @@ save_user_inputs()
 
     if [ $? -ne 0 ]; then
         echo   '入力内容の保存に失敗しました。'
-        encrypt_remove_file
         return
     fi
 

--- a/password_manager.sh
+++ b/password_manager.sh
@@ -24,18 +24,28 @@ validation_user_inputs()
     done
 }
 
+encrypt_remove_file()
+{
+        gpg --symmetric --yes --output user_inputs.gpg user_inputs
+        rm user_inputs
+}
+
 save_user_inputs()
 {
+    # TODO:複合化
+    # gpg -d --yes --output user_inputs user_inputs.gpg
     (
         echo "${user_inputs['service_name']}":"${user_inputs['user_name']}":"${user_inputs['password']}" >> user_inputs
     ) 2>> error.txt
 
     if [ $? -ne 0 ]; then
         echo   '入力内容の保存に失敗しました。'
+        encrypt_remove_file
         return
     fi
 
     echo 'パスワードの追加は成功しました。'
+    encrypt_remove_file
 }
 
 add_password()


### PR DESCRIPTION
### 概要
- パスワードを保存したファイルの暗号化し、元をファイルを削除する処理追加しました。(ファイルの管理のみ実装。パスワードの追記保存は未実装)

### 変更箇所
- パスワードを保存した`user_inputs`ファイルを`user_inputs.gpg`に暗号化
- セキュリティ維持の為、`user_inputs`を削除
- 暗号化ファイル`user_inputs.gpg`を`.gitignore`に追加し追跡対象から除外

### 手動テストによる動作確認済の事項
- `user_inputs.gpg`を開き、`user_inputs`の暗号化を確認
- `urer_inputs.gpg`を復元化し、正常にパスワードが保存されている事を確認

### 作業の切り分け:次回の作業に引き継ぎ
- パスワードを追記して暗号化する処理を追加
- 入力内容の保存に失敗した場合、複合化されたファイルを削除する処理を追加