### PR TITLE
feat:暗号化データを追記する為、暗号化ファイルを復元する処理を追加

### DIFF
--- a/password_manager.sh
+++ b/password_manager.sh
@@ -26,14 +26,15 @@ validation_user_inputs()
 
 encrypt_remove_file()
 {
+        # TODO:ターミナルへの出力捨てる
         gpg --symmetric --yes --output user_inputs.gpg user_inputs
         rm user_inputs
 }
 
 save_user_inputs()
 {
-    # TODO:複合化
-    # gpg -d --yes --output user_inputs user_inputs.gpg
+    # TODO:初回のみ、エラーが出るのでファイルを作成
+        gpg -d --yes --output user_inputs user_inputs.gpg
     (
         echo "${user_inputs['service_name']}":"${user_inputs['user_name']}":"${user_inputs['password']}" >> user_inputs
     ) 2>> error.txt


### PR DESCRIPTION
### 概要
- 暗号化ファイルを復元する処理を追加し、暗号化ファイルが上書きされる問題に対応しました。

### 変更箇所
- `user_inputs.gpg`を復元し、復元データを`user_inputs`ファイルに出力する処理を追加。新しく追加された入力データを`user_inpuds`に追記し、再度暗号化。

### 手動テストによる動作確認済の事項
- 'user_inputs.gpg'復元後に出力し、データが追記されている事を確認 

### 作業の切り分け:次回の作業に引き継ぎ
- gpgコマンドによるターミナルへのメッセージ出力を調整