### PR TITLE
fix:ファイル復元時、ターミナルへのメッセージ出力をリダイレクトする処理を追加

### DIFF
--- a/password_manager.sh
+++ b/password_manager.sh
@@ -33,8 +33,7 @@ encrypt_remove_file()
 
 save_user_inputs()
 {
-    # TODO:初回のみ、エラーが出るのでファイルを作成
-        gpg -d --yes --output user_inputs user_inputs.gpg
+        gpg -d --yes --output user_inputs user_inputs.gpg 2>> error.txt
     (
         echo "${user_inputs['service_name']}":"${user_inputs['user_name']}":"${user_inputs['password']}" >> user_inputs
     ) 2>> error.txt


### PR DESCRIPTION
### 概要
- ファイル復元時、ターミナルへのメッセージ出力をリダイレクトする事で、ユーザーに不要なメッセージを抑制する処理を追加しました。

### 変更箇所
- gpgコマンドによるターミナルへのメッセージ出力をリダイレクト
1. スクリプト初回実行時、復元の対象となる`user_inputs.gpg`が存在しない事によるエラー文を`error.txt`へリダイレクト
2. 復元化完了時、`gpg`コマンドの復元に関するメッセージを`error.txt`へリダイレクト

### 手動テストによる動作確認済の事項
- メッセージの`error.txt`への追記を確認

### その他
- `user_inputs.gpg`の事前作成も考慮したが、暗号化されたデータがそのファイル内に存在しない場合、エラー文が出力されてしまう。エラーの影響が少ない事から、エラー文をリダイレクトする方法を選択。
