### PR TITLE
fix:エラーハンドリングを追加し、ファイル暗号化失敗時の処理を改善

### DIFF
--- a/password_manager.sh
+++ b/password_manager.sh
@@ -26,8 +26,12 @@ validation_user_inputs()
 
 encrypt_remove_file()
 {
-        # TODO:ターミナルへの出力捨てる
-        gpg --symmetric --yes --output user_inputs.gpg user_inputs
+        gpg --symmetric --yes --output user_inputs.gpg user_inputs 2>> error.txt
+        if [ $? -ne 0 ]; then
+            echo 'ファイルの暗号化に失敗しました。'
+            rm user_inputs
+            return 1
+        fi
         rm user_inputs
 }
 
@@ -43,8 +47,12 @@ save_user_inputs()
         return
     fi
 
-    echo 'パスワードの追加は成功しました。'
     encrypt_remove_file
+    # ファイルの暗号化に失敗した場合、メニュー選択に戻る
+    if [ $? -ne 0 ]; then
+        return
+    fi
+    echo 'パスワードの追加は成功しました。'
 }
 
 add_password()


### PR DESCRIPTION
### 概要
- 条件分岐によるエラーハンドリングを追加し、ファイル暗号化失敗時にエラーメッセージを出力する処理を追加しました。

### 変更箇所
- 暗号化失敗時
1. `gpg`コマンドのエラーメッセージを`error.txt`に追記
2. エラーメッセージをユーザーに表示し、データの保存失敗を通知
3. セキュリティ維持の為、復元化したファイルは削除
4. 処理を中断し、メニュー選択へ戻る

### 手動テストによる動作確認済の事項
- `error.txt`へのエラーメッセージの追記を確認
- ユーザーへのエラーメッセージ出力を確認
- 復元化したファイル削除の確認
- メニュー選択への復帰を確認