### PR TITLE
fix:不要な暗号化処理を削除

### DIFF
--- a/password_manager.sh
+++ b/password_manager.sh
@@ -96,11 +96,10 @@ get_password()
     matched_data=$(grep "^$search_name" user_inputs)
     if [ $? -eq 0 ]; then
         echo "$matched_data" | awk -F ':' '{print "サービス名:"$1 "\nユーザー名:"$2 "\nパスワード:"$3"\n"}'
-        encrypt_remove_file
     else
         echo -e 'そのサービスは登録されていません。\n'
-        rm user_inputs
     fi
+    rm user_inputs
 }
 
 echo 'パスワードマネージャーへようこそ！'


### PR DESCRIPTION
### 概要
- 復元化したファイルの再暗号化処理を行っていましたが、再暗号化が不要な為、該当処理を削除しました。

### 変更箇所
- 挿入していた`encrypt_remove_file`関数を削除
- ファイル暗号化の成否に関わらず、復元化したファイルを削除する為、処理の場所を移動

### 手動テストによる動作確認済の事項
- 継続した`user_input.gpg`ファイルの暗号化を確認
- 復元化した`user_inputs`ファイルの削除を確認