### PR TITLE
fix:復元化処理の出力先をgrepコマンドへ修正

### DIFF
--- a/password_manager.sh
+++ b/password_manager.sh
@@ -82,24 +82,20 @@ add_password()
 
 get_password()
 {
-    gpg -d --yes --output user_inputs user_inputs.gpg 2>> error.txt
-
     # ユーザー入力を確認
     read -p 'サービス名を入力してください:' search_name
         if [ -z "$search_name" ]; then
             echo -e "\nサービス名が入力されていません。"
-            rm user_inputs
             return
         fi
 
     # 入力されたサービス名のデータを確認
-    matched_data=$(grep "^$search_name" user_inputs)
+    matched_data=$(gpg -d --yes user_inputs.gpg 2>> error.txt | grep "^$search_name" )
     if [ $? -eq 0 ]; then
         echo "$matched_data" | awk -F ':' '{print "サービス名:"$1 "\nユーザー名:"$2 "\nパスワード:"$3"\n"}'
     else
         echo -e 'そのサービスは登録されていません。\n'
     fi
-    rm user_inputs
 }
 
 echo 'パスワードマネージャーへようこそ！'


### PR DESCRIPTION
### 概要
- 復元化処理の出力先をファイルからgrepコマンドへ修正し、仕様と異なっていた部分を訂正しました。

### 変更箇所
- `gpg`コマンドの出力をパイプで`grep`に渡し、サービス名に関する情報を検索する処理に変更
- 復元化したファイルを削除する処理は不要な為、削除

### 手動テストによる動作確認済の事項
- `get password`関数を実行し、正常な処理の実施を確認
- `user_input.gpg`ファイルの継続した暗号化状態を確認
