### PR TITLE
fix:復元化されたファイルを削除する処理を追加

### DIFF
--- a/password_manager.sh
+++ b/password_manager.sh
@@ -17,11 +17,12 @@ save_user_inputs()
 {
         gpg -d --yes --output user_inputs.txt user_inputs.gpg 2>> error.txt
     (
-        echo "${user_inputs['service_name']}":"${user_inputs['user_name']}":"${user_inputs['password']}" >> user_inputs.txt
+        echo "${user_inputs['service_name']}":"${user_inputs['user_name']}":"${user_inputs['password']}" >> d/user_inputs.txt
     ) 2>> error.txt
 
     if [ $? -ne 0 ]; then
         echo   '入力内容の保存に失敗しました。'
+        rm user_inputs.txt
         return
     fi
 


### PR DESCRIPTION
### 概要
- エラー発生時、復元化されたファイルが削除されてない状態だった為、削除する処理を追加しました。

### 変更箇所
- 復元化されたファイルを削除する処理の追加

### 手動テストによる動作確認済の事項
- 削除処理が正常に動作することを確認