### PR TITLE
fix:ユーザー入力の保存失敗時、処理を中断するreturnを追加

### DIFF
--- a/password_manager.sh
+++ b/password_manager.sh
@@ -15,15 +15,15 @@ encrypt_remove_file()
 
 save_user_inputs()
 {
-        gpg -d --yes --output user_inputs.txt user_inputs.gpg 2>> error.txt
+    gpg -d --yes --output user_inputs.txt user_inputs.gpg 2>> error.txt
     (
         echo "${user_inputs['service_name']}":"${user_inputs['user_name']}":"${user_inputs['password']}" >> user_inputs.txt
     ) 2>> error.txt
 
     if [ $? -ne 0 ]; then
-        echo   '入力内容の保存に失敗しました。'
+        echo '入力内容の保存に失敗しました。'
         rm user_inputs.txt
-        return
+        return 1
     fi
 }
 
@@ -63,10 +63,9 @@ add_password()
     echo ''
 
     validation_user_inputs
-# TODO:入力保存に失敗した場合の中断処理を修正
     if [ -z "$error_messages" ]; then
         # 入力が正常な場合、入力を保存
-        save_user_inputs
+        save_user_inputs || return
     else
         # 入力に異常がある場合、配列のエラー文を出力
         for error in "${error_messages[@]}"; do


### PR DESCRIPTION
### 概要
- `encrypt_remove_file`関数の分離に対応し、ユーザー入力の保存失敗時、`return1`を返し処理を中断するよう変更しました。

### 変更箇所
- `save_user_inputs`関数の処理失敗時、`return 1`で終了ステータスを返し処理を中断
- 不要なインデントを修正

### 手動テストによる動作確認済の事項
- リダイレクト失敗によるエラー発生時、処理の中断とエラーメッセージ出力を確認
- 正常に処理が行われた場合、ファイルへのデータ保存を確認
