### PR TITLE
ref:get passwordにおける終了ステータス取得処理を追加

### DIFF
--- a/password_manager.sh
+++ b/password_manager.sh
@@ -101,11 +101,21 @@ get_password()
         fi
 
     # 入力されたサービス名のデータを確認
+    declare -A result
+    # 複合化、サービス名の検索、仕様に則した出力
     gpg -d --yes user_inputs.gpg 2>> error.txt |
      grep "^$search_name" |
      awk -F ':' '$1 !="" {print "サービス名:"$1 "\nユーザー名:"$2 "\nパスワード:"$3"\n"}'
 
+    # 各コマンドの終了ステータスの取得
+    result=(
+            ['decrypt_error']="${PIPESTATUS[0]}"
+            ['search_error']="${PIPESTATUS[1]}"
+            ['output_error']="${PIPESTATUS[2]}"
+    )
+    echo "${result[@]}"
     # TODO:エラーハンドリングを追加
+
 }
 
 echo 'パスワードマネージャーへようこそ！'


### PR DESCRIPTION
### 概要
- `Get Password`において、終了ステータスに基づくエラーハンドリングでを行うため、終了ステータス取得処理を追加しました。

### 変更箇所
- 終了ステータスを連想配列で取得し、`result`に代入

### 手動テストによる動作確認済の事項
- `result`を出力し、終了ステータスの正常な代入を確認

### 作業の切り分け:次回の作業に引き継ぎ
- エラーハンドリングを追加
