### PR TITLE
ref:`Get Password`におけるエラーハンドリングを追加

### DIFF
--- a/password_manager.sh
+++ b/password_manager.sh
@@ -114,13 +114,12 @@ get_password()
             ['output_error']="${PIPESTATUS[2]}"
     )
 
-    # TODO:エラーハンドリングを追加
     if [ "${result['decrypt_error']}" -ne 0 ]; then
         if tail -n 1 error.txt | grep -E 'Bad session key|No secret key' > /dev/null; then
-            echo 'パスフレーズが間違っています。'
+            echo -e 'パスフレーズが間違っています。\n'
             gpgconf --reload gpg-agent
         else
-            echo 'ファイルの復号化に失敗しました。'
+            echo -e 'ファイルの復号化に失敗しました。\n'
         fi
     elif [ "${result['search_error']}" -ne 0 ]; then
         echo -e 'そのサービスは登録されていません。\n'


### PR DESCRIPTION
### 概要
- `Get Password`におけるエラーハンドリングを追加し、出力過程のエラーに基づいて、エラーメッセージを出力する処理を追加

### 変更箇所
- `result`の値を判別し、必要に応じてエラーメッセージを出力
- 誤ったパスフレーズがキャッシュされる事がある為、パスフレーズを間違えた場合はキャッシュを削除

### 手動テストによる動作確認済の事項
- 出力過程にエラーがあった場合、適切なエラーメッセージを出力
- 処理が正常な場合、保存した情報が出力される事を確認
- パスワードファイルの暗号化維持を確認
