### PR TITLE
ref:配列の宣言をlocalによる宣言に修正

### DIFF
--- a/password_manager.sh
+++ b/password_manager.sh
@@ -101,8 +101,7 @@ get_password()
         fi
 
     # 入力されたサービス名のデータを確認
-    # TODO:localで宣言
-    declare -A result
+    local -A result
     # 複合化、サービス名の検索、仕様に則した出力
     gpg -d --yes user_inputs.gpg 2>> error.txt |
         grep "^$search_name" 2>> error.txt |


### PR DESCRIPTION
- スコープを修正し、変数名の衝突を避けるため

### 手動テストによる動作確認済の事項
- コードを実行し、正常な動作を確認

### 作業の切り分け:次回の作業に引き継ぎ
- 特になし
